### PR TITLE
added callback_query answer

### DIFF
--- a/main.py
+++ b/main.py
@@ -319,7 +319,7 @@ def rateProf(update, context):
 
 def ratebutton(update, context):
     query = update.callback_query
-
+    query.answer()
     userId = str(update.effective_message.chat_id)
 
     data = query.data[10:].split(';')


### PR DESCRIPTION
This method needed to send answers to callback queries sent from inline keyboards, so that the "Loading" label could disappear from the user's navigation bar.